### PR TITLE
Update README.md documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 [![Maven Central Version](https://img.shields.io/maven-central/v/com.soywiz/korlibs-image)](https://central.sonatype.com/artifact/com.soywiz/korlibs-image)
 [![Discord](https://img.shields.io/discord/728582275884908604?logo=discord&label=Discord)](https://discord.korge.org/)
 [![KDoc](https://img.shields.io/badge/docs-kdoc-blue)](https://korlibs.github.io/korlibs-image/)
-[![Documentation](https://img.shields.io/badge/docs-documentation-purple)](https://docs.korge.org/image/)
+[![Documentation](https://img.shields.io/badge/docs-documentation-purple)](https://docs.korge.org/imaging/)
 <!-- /BADGES -->


### PR DESCRIPTION
The old https://docs.korge.org/image leads to 404 page.
Instead, it's updated to https://docs.korge.org/imaging.